### PR TITLE
ST3 MacOS fix unicode decode error for utf-8 files

### DIFF
--- a/Modific.py
+++ b/Modific.py
@@ -101,7 +101,6 @@ class CommandThread(threading.Thread):
         try:
             # Per http://bugs.python.org/issue8557 shell=True is required to
             # get $PATH on Windows. Yay portable code.
-            shell = os.name == 'nt'
             if self.working_dir != "":
                 os.chdir(self.working_dir)
 
@@ -110,8 +109,7 @@ class CommandThread(threading.Thread):
 
             proc = subprocess.Popen(self.command,
                 stdout=self.stdout, stderr=subprocess.STDOUT,
-                stdin=subprocess.PIPE,
-                shell=shell, universal_newlines=True)
+                stdin=subprocess.PIPE)
             output = proc.communicate(self.stdin)[0]
             if not output:
                 output = ''


### PR DESCRIPTION
I don't know why but it works only with this. Raises unicode decode error if file contains non-ascii symbols in other case.
