### PR TITLE
Do not save after ReplaceModifiedPart

### DIFF
--- a/Modific.py
+++ b/Modific.py
@@ -534,7 +534,6 @@ class ReplaceModifiedPartCommand(DiffCommand, sublime_plugin.TextCommand):
                     self.view.run_command('edit_view', dict(command='erase', region=[region.begin(), region.end()]))
             else:
                 self.view.run_command('edit_view', dict(command='insert', begin=begin, output=content + os.linesep))
-            self.view.run_command('save')
 
 
 class HlChangesBackground(sublime_plugin.EventListener):


### PR DESCRIPTION
This is not at all expected in my opinion and actually caused me to lose a bit of work earlier. And on top of it not being expected, it also does not update the tab's dirty state correctly. I really think auto-saving after this command is dangerous and unneeded.
