### PR TITLE
Add command to toggle highlight_changes

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -3,6 +3,7 @@
     { "keys": ["ctrl+alt+r"], "command": "replace_modified_part" },
     { "keys": ["ctrl+alt+d"], "command": "show_diff" },
     { "keys": ["ctrl+alt+u"], "command": "uncommitted_files" },
+    { "keys": ["ctrl+alt+t"], "command": "toggle_highlight_changes" },
 
     { "keys": ["ctrl+shift+pageup"], "command": "jump_between_changes", "args": {"direction": "prev"} },
     { "keys": ["ctrl+shift+pagedown"], "command": "jump_between_changes", "args": {"direction": "next"} }

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -3,6 +3,7 @@
     { "keys": ["ctrl+super+r"], "command": "replace_modified_part" },
     { "keys": ["ctrl+alt+d"], "command": "show_diff" },
     { "keys": ["ctrl+super+u"], "command": "uncommitted_files" },
+    { "keys": ["ctrl+super+t"], "command": "toggle_highlight_changes" },
 
     { "keys": ["ctrl+shift+pageup"], "command": "jump_between_changes", "args": {"direction": "prev"} },
     { "keys": ["ctrl+shift+pagedown"], "command": "jump_between_changes", "args": {"direction": "next"} }

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -3,6 +3,7 @@
     { "keys": ["ctrl+alt+r"], "command": "replace_modified_part" },
     { "keys": ["ctrl+alt+d"], "command": "show_diff" },
     { "keys": ["ctrl+alt+u"], "command": "uncommitted_files" },
+    { "keys": ["ctrl+alt+t"], "command": "toggle_highlight_changes" },
 
     { "keys": ["ctrl+shift+pageup"], "command": "jump_between_changes", "args": {"direction": "prev"} },
     { "keys": ["ctrl+shift+pagedown"], "command": "jump_between_changes", "args": {"direction": "next"} }

--- a/Modific.py
+++ b/Modific.py
@@ -784,3 +784,14 @@ class UncommittedFilesCommand(VcsCommand, sublime_plugin.WindowCommand):
                     self.window.open_file(os.path.join(self.vcs['root'], fname))
                 else:
                     sublime.status_message("File '{0}' doesn't exist".format(fname))
+
+
+class ToggleHighlightChangesCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        v_setting = "highlight_changes"
+        if get_settings().get(v_setting):
+        	get_settings().set(v_setting, False)
+        	self.view.run_command('save')
+        else:
+        	get_settings().set(v_setting, True)
+        	self.view.run_command('save')

--- a/Modific.py
+++ b/Modific.py
@@ -789,9 +789,13 @@ class UncommittedFilesCommand(VcsCommand, sublime_plugin.WindowCommand):
 class ToggleHighlightChangesCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         v_setting = "highlight_changes"
-        if get_settings().get(v_setting):
-        	get_settings().set(v_setting, False)
+        settings = get_settings()
+
+        if settings.get(v_setting):
+        	settings.set(v_setting, False)
         	self.view.run_command('save')
         else:
-        	get_settings().set(v_setting, True)
+        	settings.set(v_setting, True)
         	self.view.run_command('save')
+        
+        sublime.save_settings("Modific.sublime-settings")

--- a/Modific.sublime-commands
+++ b/Modific.sublime-commands
@@ -14,5 +14,9 @@
     {
         "caption": "Modific: Show uncommitted files",
         "command": "uncommitted_files"
+    },
+    {
+        "caption": "Modific: Toggle highlight changes",
+        "command": "toggle_highlight_changes"
     }
 ]


### PR DESCRIPTION
Problem: The gutter only draws an icon at a time, and sometimes we need to see bookmark icons, or sublimeLinter icons.

Added a command to enable/disable highlight_changes setting and auto saving.