### PR TITLE
Added options whether jump_between_changes should wrap around and whether the uncommitted_files command should use a monospace font

### DIFF
--- a/Modific.py
+++ b/Modific.py
@@ -772,7 +772,10 @@ class UncommittedFilesCommand(VcsCommand, sublime_plugin.WindowCommand):
     def show_status_list(self):
         options = copy(self.results)
         options.insert(0, " - Open All")
-        self.get_window().show_quick_panel(options, self.panel_done, sublime.MONOSPACE_FONT)
+        if self.settings.get('uncommitted_files_use_monospace_font', True):
+            self.get_window().show_quick_panel(options, self.panel_done, sublime.MONOSPACE_FONT)
+        else:
+            self.get_window().show_quick_panel(options, self.panel_done)
 
     def panel_done(self, picked):
         if picked == 0:

--- a/Modific.py
+++ b/Modific.py
@@ -627,10 +627,11 @@ class JumpBetweenChangesCommand(DiffCommand, sublime_plugin.TextCommand):
                 jump_to = line
                 break
 
-        if not jump_to:
+        if not jump_to and self.settings.get('jump_between_changes_wraps_around', True):
             jump_to = lines[0]
 
-        self.goto_line(edit, jump_to)
+        if jump_to is not None:
+            self.goto_line(edit, jump_to)
 
     def goto_line(self, edit, line):
         # Convert from 1 based to a 0 based line number

--- a/Modific.sublime-settings
+++ b/Modific.sublime-settings
@@ -44,5 +44,8 @@
     "max_file_size": 1024,
 
     // Whether the jump_between_changes command should wrap around to the beginning/end.
-    "jump_between_changes_wraps_around": true
+    "jump_between_changes_wraps_around": true,
+
+    // Whether the uncommitted_files command should use a monospace font to dosplay the file list.
+    "uncommitted_files_use_monospace_font": true
 }

--- a/Modific.sublime-settings
+++ b/Modific.sublime-settings
@@ -44,5 +44,5 @@
     "max_file_size": 1024,
 
     // Whether the jump_between_changes command should wrap around to the beginning/end.
-    "jump_between_changes_wraps_around": True
+    "jump_between_changes_wraps_around": true
 }

--- a/Modific.sublime-settings
+++ b/Modific.sublime-settings
@@ -44,5 +44,5 @@
     "max_file_size": 1024,
 
     // Whether the jump_between_changes command should wrap around to the beginning/end.
-    "jump_between_changes_wraps_around": true
+    "jump_between_changes_wraps_around": True
 }

--- a/Modific.sublime-settings
+++ b/Modific.sublime-settings
@@ -44,5 +44,5 @@
     "max_file_size": 1024,
 
     // Whether the jump_between_changes command should wrap around to the beginning/end.
-    "jump_between_changes_wraps_around": false
+    "jump_between_changes_wraps_around": true
 }

--- a/Modific.sublime-settings
+++ b/Modific.sublime-settings
@@ -41,5 +41,8 @@
     "svn_use_internal_diff": false,
 
     // File size limit (in KB) for drawing icons on the gutter
-    "max_file_size": 1024
+    "max_file_size": 1024,
+
+    // Whether the jump_between_changes command should wrap around to the beginning/end.
+    "jump_between_changes_wraps_around": false
 }


### PR DESCRIPTION
This change allows specifying if the jump_between_changes command should wrap around, when at the beginning/end of the changes.