### PR TITLE
Added option to not add region icons.

### DIFF
--- a/Modific.py
+++ b/Modific.py
@@ -511,14 +511,17 @@ class HlChangesCommand(DiffCommand, sublime_plugin.TextCommand):
             return
 
         icon = self.settings.get('region_icon') or 'modific'
-        if icon == 'modific':
-            if IS_ST3:
-                icon = 'Packages/Modific/icons/' + hl_key + '.png'
-            else:
-                icon = '../Modific/icons/' + hl_key
-        points = [self.view.text_point(l - 1, 0) for l in lines]
-        regions = [sublime.Region(p, p) for p in points]
-        self.view.add_regions(hl_key, regions, "markup.%s.diff" % hl_key, icon, sublime.HIDDEN | sublime.DRAW_EMPTY)
+        if icon != 'none':
+            if icon == 'modific':
+                if IS_ST3:
+                    icon = 'Packages/Modific/icons/' + hl_key + '.png'
+                else:
+                    icon = '../Modific/icons/' + hl_key
+            elif icon == 'none':
+                icon = ''
+            points = [self.view.text_point(l - 1, 0) for l in lines]
+            regions = [sublime.Region(p, p) for p in points]
+            self.view.add_regions(hl_key, regions, "markup.%s.diff" % hl_key, icon, sublime.HIDDEN | sublime.DRAW_EMPTY)
 
     def diff_done(self, diff):
         self.log('on hl_changes:', diff)

--- a/Modific.sublime-settings
+++ b/Modific.sublime-settings
@@ -4,7 +4,8 @@
     "highlight_changes": true,
 
     // Name of a region icon
-    // Valid icon names are: modific, dot, circle, bookmark and cross
+    // Valid icon names are: modific, dot, circle, bookmark, cross, and none
+    // If 'none' is used, modific does not add region icons.
     // WARNING: if you set value different than 'modific',
     //          you may experience issues with UI of Sublime.
     //          See https://github.com/gornostal/Modific/issues/9


### PR DESCRIPTION
Recently, Sublime Text gained some mini diff functionality, which works similar to modifics region icons. The new native mini diff has the advantage, that the region icon remains free for other usages like bookmarks.

Build 3189 also gained Goto/Next Modification, but I don't like its highlighting, and still prefer modifics way of doing it. I also don't like that it wrapps around.

Finally I enjoy a lot of the other modific commands like show_diff, replace_modified_part, and uncommitted_files, leaving modific far from being obsolete to me.