### PR TITLE
Remove double quotes from status command output

### DIFF
--- a/Modific.py
+++ b/Modific.py
@@ -713,7 +713,7 @@ class UncommittedFilesCommand(VcsCommand, sublime_plugin.WindowCommand):
 
     def filter_unified_status(self, result):
         return list(filter(lambda x: len(x) > 0 and not x.lstrip().startswith('>'),
-                    result.rstrip().split('\n')))
+                    result.rstrip().replace('"', '').split('\n')))
 
     def git_filter_status(self, result):
         return self.filter_unified_status(result)


### PR DESCRIPTION
For some reason git status --porcelain adds double quotes to certain file names like this:

$ git status --porcelain
 M Core/Src/config.h
 M Core/Src/control.c
 M Core/Src/sixaxis.c
 M "MDK-ARM/STM32F411 NOXE.uvoptx"
 M "MDK-ARM/STM32F411 NOXE.uvprojx"
?? MDK-ARM/New Text Document.uvoptx

I'm not sure what's the criteria, because they are not added for example to New Text Document.uvoptx. Maybe because it's not modified but untracked.

However, the files from the list with the double quotes cannot be opened from the quick panel.

The proposed file change removes all double quotes from the output, and fixes the issue.