### PR TITLE
missing image resources at ST4

### DIFF
--- a/Modific.py
+++ b/Modific.py
@@ -11,7 +11,7 @@ import functools
 import re
 from copy import copy
 
-IS_ST3 = sublime.version().startswith('3')
+IS_ST3 = sublime.version().startswith('3') or sublime.version().startswith('4')
 
 
 def get_settings():


### PR DESCRIPTION
As already mentioned at [SublimeText 4 support](#110) - all credits to [franc-paul](https://github.com/franck-paul), there is a check for ST3 only.  The ST4 is considred to be ST2.